### PR TITLE
Clearer error raised when function gives improper HTTP response return

### DIFF
--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -66,15 +66,20 @@ class WSGIApp:
 
         if match:
             args, route = match
-            try:
-                status, headers, resp_data = route["func"](request, *args)
-            except TypeError as err:
+            response_params = route["func"](request, *args)
+            if (
+                not (
+                    isinstance(response_params, list)
+                    or isinstance(response_params, tuple)
+                )
+                or len(response_params) != 3
+            ):
                 raise RuntimeError(
                     "Proper HTTP response return not given for request handler '{}'".format(
                         route["func"].__name__
                     )
-                ) from err
-
+                )
+            status, headers, resp_data = response_params
         start_response(status, headers)
         return resp_data
 

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -66,7 +66,14 @@ class WSGIApp:
 
         if match:
             args, route = match
-            status, headers, resp_data = route["func"](request, *args)
+            try:
+                status, headers, resp_data = route["func"](request, *args)
+            except TypeError as err:
+                raise RuntimeError(
+                    "Proper HTTP response return not given for request handler '{}'".format(
+                        route["func"].__name__
+                    )
+                ) from err
 
         start_response(status, headers)
         return resp_data

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -66,17 +66,12 @@ class WSGIApp:
 
         if match:
             args, route = match
-            response_params = route["func"](request, *args)
-            if (
-                not isinstance(response_params, (list, tuple))
-                or len(response_params) != 3
-            ):
+            try:
+                status, headers, resp_data = route["func"](request, *args)
+            except ValueError, TypeError:
                 raise RuntimeError(
                     "Proper HTTP response return not given for request handler '{}'".format(
                         route["func"].__name__
-                    )
-                )
-            status, headers, resp_data = response_params
         start_response(status, headers)
         return resp_data
 

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -68,10 +68,7 @@ class WSGIApp:
             args, route = match
             response_params = route["func"](request, *args)
             if (
-                not (
-                    isinstance(response_params, list)
-                    or isinstance(response_params, tuple)
-                )
+                not isinstance(response_params, (list, tuple))
                 or len(response_params) != 3
             ):
                 raise RuntimeError(

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -68,10 +68,12 @@ class WSGIApp:
             args, route = match
             try:
                 status, headers, resp_data = route["func"](request, *args)
-            except ValueError, TypeError:
+            except (ValueError, TypeError) as err:
                 raise RuntimeError(
                     "Proper HTTP response return not given for request handler '{}'".format(
                         route["func"].__name__
+                    )
+                ) from err
         start_response(status, headers)
         return resp_data
 


### PR DESCRIPTION
Resolves #11 by transforming `TypeError` into `RuntimeError` that also references that faulty method/function in question.  I do this all the time (-_-").  It will explicitly check for a list or tuple of length 3, which is the expected response for a request handler.

Tested on `Adafruit CircuitPython 7.1.1 on 2022-01-14; Adafruit Pybadge with samd51j19` with AirLift FeatherWing