### PR TITLE
#16 use the request path in the exception

### DIFF
--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -70,7 +70,8 @@ class WSGIApp:
                 status, headers, resp_data = route["func"](request, *args)
             except (ValueError, TypeError) as err:
                 raise RuntimeError(
-                    f"Proper HTTP response return not given for request handler for path '{request.path}'"
+                    f"Proper HTTP response return not given for request handler for path \
+                        '{request.path}'"
                 ) from err
         start_response(status, headers)
         return resp_data

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -71,7 +71,7 @@ class WSGIApp:
             except (ValueError, TypeError) as err:
                 raise RuntimeError(
                     "Proper HTTP response not returned by request handler for path "
-                    + "'{request.path}'"
+                    + f"'{request.path}'"
                 ) from err
         start_response(status, headers)
         return resp_data

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -70,8 +70,8 @@ class WSGIApp:
                 status, headers, resp_data = route["func"](request, *args)
             except (ValueError, TypeError) as err:
                 raise RuntimeError(
-                    f"Proper HTTP response return not given for request handler for path \
-                        '{request.path}'"
+                    "Proper HTTP response not returned by request handler for path "
+                        + "'{request.path}'"
                 ) from err
         start_response(status, headers)
         return resp_data

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -71,7 +71,7 @@ class WSGIApp:
             except (ValueError, TypeError) as err:
                 raise RuntimeError(
                     "Proper HTTP response return not given for request handler '{}'".format(
-                        route["func"].__name__
+                        request.path
                     )
                 ) from err
         start_response(status, headers)

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -71,7 +71,7 @@ class WSGIApp:
             except (ValueError, TypeError) as err:
                 raise RuntimeError(
                     "Proper HTTP response not returned by request handler for path "
-                        + "'{request.path}'"
+                    + "'{request.path}'"
                 ) from err
         start_response(status, headers)
         return resp_data

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -70,7 +70,7 @@ class WSGIApp:
                 status, headers, resp_data = route["func"](request, *args)
             except (ValueError, TypeError) as err:
                 raise RuntimeError(
-                    "Proper HTTP response return not given for request handler '{}'".format(
+                    "Proper HTTP response return not given for request path '{}'".format(
                         request.path
                     )
                 ) from err

--- a/adafruit_wsgi/wsgi_app.py
+++ b/adafruit_wsgi/wsgi_app.py
@@ -70,9 +70,7 @@ class WSGIApp:
                 status, headers, resp_data = route["func"](request, *args)
             except (ValueError, TypeError) as err:
                 raise RuntimeError(
-                    "Proper HTTP response return not given for request path '{}'".format(
-                        request.path
-                    )
+                    f"Proper HTTP response return not given for request handler for path '{request.path}'"
                 ) from err
         start_response(status, headers)
         return resp_data


### PR DESCRIPTION
Fixes #16.
Output looks like:
```
Traceback (most recent call last):
  File "code.py", line 1, in <module>
  File "counting.py", line 23, in <module>
  File "robot_wifi.py", line 52, in start_wifi_server
  File "adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py", line 105, in update_poll
  File "/lib/adafruit_wsgi/wsgi_app.py", line 74, in __call__
RuntimeError: Proper HTTP response return not given for request handler '/count'
```
